### PR TITLE
Add Azure AD protected Web API project

### DIFF
--- a/AuthApi.csproj
+++ b/AuthApi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.19.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/Authorization/RoleAuthorizationHandler.cs
+++ b/Authorization/RoleAuthorizationHandler.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AuthApi.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthApi.Authorization
+{
+    public class RoleAuthorizationHandler : AuthorizationHandler<RoleRequirement>
+    {
+        private readonly AuthDbContext _dbContext;
+
+        public RoleAuthorizationHandler(AuthDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, RoleRequirement requirement)
+        {
+            var email = context.User.FindFirst("preferred_username")?.Value
+                         ?? context.User.FindFirst("upn")?.Value
+                         ?? context.User.FindFirst(ClaimTypes.Name)?.Value;
+
+            if (string.IsNullOrEmpty(email))
+            {
+                return;
+            }
+
+            var user = await _dbContext.Users
+                .Include(u => u.UserRoles)
+                    .ThenInclude(ur => ur.Role)
+                .FirstOrDefaultAsync(u => u.Email == email && u.IsActive);
+
+            if (user == null)
+            {
+                return;
+            }
+
+            if (user.UserRoles.Any(ur => ur.Role.Name == requirement.RoleName))
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/Authorization/RoleRequirement.cs
+++ b/Authorization/RoleRequirement.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace AuthApi.Authorization
+{
+    public class RoleRequirement : IAuthorizationRequirement
+    {
+        public string RoleName { get; }
+
+        public RoleRequirement(string roleName)
+        {
+            RoleName = roleName;
+        }
+    }
+}

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AuthApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AdminController : ControllerBase
+    {
+        [HttpGet("data")]
+        [Authorize(Policy = "RequireAdminRole")]
+        public IActionResult GetData()
+        {
+            return Ok(new { Message = "Secret admin data" });
+        }
+    }
+}

--- a/Data/AuthDbContext.cs
+++ b/Data/AuthDbContext.cs
@@ -1,0 +1,61 @@
+using AuthApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthApi.Data
+{
+    public class AuthDbContext : DbContext
+    {
+        public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<User> Users => Set<User>();
+        public DbSet<Role> Roles => Set<Role>();
+        public DbSet<UserRole> UserRoles => Set<UserRole>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasDefaultSchema("auth");
+
+            modelBuilder.Entity<User>(entity =>
+            {
+                entity.ToTable("users");
+                entity.HasKey(u => u.Id);
+                entity.HasIndex(u => u.Email).IsUnique();
+                entity.Property(u => u.Email).HasMaxLength(255).IsRequired();
+                entity.Property(u => u.Name).HasMaxLength(255);
+                entity.Property(u => u.IsActive).HasDefaultValue(true);
+                entity.Property(u => u.CreatedAt).HasDefaultValueSql("GETDATE()");
+                entity.Property(u => u.UpdatedAt).HasDefaultValueSql("GETDATE()");
+            });
+
+            modelBuilder.Entity<Role>(entity =>
+            {
+                entity.ToTable("roles");
+                entity.HasKey(r => r.Id);
+                entity.HasIndex(r => r.Name).IsUnique();
+                entity.Property(r => r.Name).HasMaxLength(50).IsRequired();
+                entity.Property(r => r.RoleType).HasMaxLength(20).IsRequired();
+                entity.Property(r => r.CreatedAt).HasDefaultValueSql("GETDATE()");
+                entity.Property(r => r.UpdatedAt).HasDefaultValueSql("GETDATE()");
+                entity.HasCheckConstraint("chk_role_type", "role_type IN ('global','scoped')");
+            });
+
+            modelBuilder.Entity<UserRole>(entity =>
+            {
+                entity.ToTable("user_roles");
+                entity.HasKey(ur => new { ur.UserId, ur.RoleId });
+                entity.Property(ur => ur.CreatedAt).HasDefaultValueSql("GETDATE()");
+                entity.Property(ur => ur.UpdatedAt).HasDefaultValueSql("GETDATE()");
+                entity.HasOne(ur => ur.User)
+                    .WithMany(u => u.UserRoles)
+                    .HasForeignKey(ur => ur.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+                entity.HasOne(ur => ur.Role)
+                    .WithMany(r => r.UserRoles)
+                    .HasForeignKey(ur => ur.RoleId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            });
+        }
+    }
+}

--- a/Middleware/RoleClaimsMiddleware.cs
+++ b/Middleware/RoleClaimsMiddleware.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AuthApi.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthApi.Middleware
+{
+    public class RoleClaimsMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public RoleClaimsMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context, AuthDbContext db)
+        {
+            if (context.User.Identity?.IsAuthenticated == true)
+            {
+                var email = context.User.FindFirst("preferred_username")?.Value
+                            ?? context.User.FindFirst("upn")?.Value
+                            ?? context.User.FindFirst(ClaimTypes.Name)?.Value;
+
+                if (!string.IsNullOrEmpty(email))
+                {
+                    var roles = await db.UserRoles
+                        .Where(ur => ur.User.Email == email && ur.User.IsActive)
+                        .Select(ur => ur.Role.Name)
+                        .ToListAsync();
+
+                    var identity = (ClaimsIdentity)context.User.Identity;
+                    foreach (var role in roles)
+                    {
+                        if (!identity.HasClaim(ClaimTypes.Role, role))
+                        {
+                            identity.AddClaim(new Claim(ClaimTypes.Role, role));
+                        }
+                    }
+                }
+            }
+
+            await _next(context);
+        }
+    }
+
+    public static class RoleClaimsMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseRoleClaims(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<RoleClaimsMiddleware>();
+        }
+    }
+}

--- a/Models/Role.cs
+++ b/Models/Role.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace AuthApi.Models
+{
+    public class Role
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public string? Description { get; set; }
+        public string RoleType { get; set; } = null!;
+        public DateTime CreatedAt { get; set; }
+        public string? CreatedBy { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public string? UpdatedBy { get; set; }
+
+        public virtual ICollection<UserRole> UserRoles { get; set; } = new HashSet<UserRole>();
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace AuthApi.Models
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string Email { get; set; } = null!;
+        public string? Name { get; set; }
+        public bool IsActive { get; set; } = true;
+        public DateTime CreatedAt { get; set; }
+        public string? CreatedBy { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public string? UpdatedBy { get; set; }
+
+        public virtual ICollection<UserRole> UserRoles { get; set; } = new HashSet<UserRole>();
+    }
+}

--- a/Models/UserRole.cs
+++ b/Models/UserRole.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace AuthApi.Models
+{
+    public class UserRole
+    {
+        public int UserId { get; set; }
+        public int RoleId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string? CreatedBy { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public string? UpdatedBy { get; set; }
+
+        public virtual User User { get; set; } = null!;
+        public virtual Role Role { get; set; } = null!;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,44 @@
+using AuthApi.Authorization;
+using AuthApi.Middleware;
+using AuthApi.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+
+builder.Services.AddDbContext<AuthDbContext>(options =>
+{
+    options.UseSqlServer(connectionString);
+    options.UseLazyLoadingProxies();
+});
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("RequireAdminRole",
+        policy => policy.Requirements.Add(new RoleRequirement("Admin")));
+});
+
+builder.Services.AddScoped<IAuthorizationHandler, RoleAuthorizationHandler>();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.UseRoleClaims();
+
+app.MapControllers();
+
+app.Run();

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=AuthDb;User Id=sa;Password=your_password;TrustServerCertificate=True"
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "common",
+    "ClientId": "YOUR_CLIENT_ID",
+    "Audience": "api://YOUR_CLIENT_ID"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- setup .NET 8 Web API project
- add EF Core models and `AuthDbContext`
- implement role-based authorization handler and middleware
- configure authentication/authorization in Program
- add admin-only endpoint example

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687795c53040832da8e8695f602cfa27