### PR TITLE
Add Flower API controller with authorization

### DIFF
--- a/Controllers/FlowerController.cs
+++ b/Controllers/FlowerController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+
+namespace AuthApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class FlowerController : ControllerBase
+    {
+        private static readonly List<string> Flowers = new() { "Rose", "Tulip" };
+
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok(Flowers);
+        }
+
+        [HttpPut]
+        [Authorize(Policy = "RequireAdminRole")]
+        public IActionResult Add([FromBody] string flower)
+        {
+            if (!string.IsNullOrWhiteSpace(flower))
+            {
+                Flowers.Add(flower);
+            }
+            return Ok(Flowers);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `FlowerController`
- implement GET to return flowers
- implement PUT to append flowers and restrict to `RequireAdminRole`
- apply controller-level `[Authorize]`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687797bf9af0832d84d824ad286cdb44