### PR TITLE
Add Swagger support and landing page link

### DIFF
--- a/AuthApi.csproj
+++ b/AuthApi.csproj
@@ -10,5 +10,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.19.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Identity.Web;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,8 +30,16 @@ builder.Services.AddAuthorization(options =>
 builder.Services.AddScoped<IAuthorizationHandler, RoleAuthorizationHandler>();
 
 builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Auth API", Version = "v1" });
+});
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 
@@ -40,5 +49,8 @@ app.UseAuthorization();
 app.UseRoleClaims();
 
 app.MapControllers();
+app.MapGet("/", () => Results.Content(
+    "<html><body><a href=\"/swagger/index.html\">Swagger UI</a></body></html>",
+    "text/html"));
 
 app.Run();


### PR DESCRIPTION
## Summary
- install Swashbuckle.AspNetCore for Swagger support
- register Swagger services in Program
- enable Swagger middleware
- show a landing page with a link to `/swagger/index.html`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68779cf6e62c832da4fea319934da393