### PR TITLE
Add logout action and display tokens on homepage

### DIFF
--- a/AADConnect/Controllers/HomeController.cs
+++ b/AADConnect/Controllers/HomeController.cs
@@ -1,14 +1,35 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace AADConnect.Controllers
 {
     public class HomeController : Controller
     {
         [AllowAnonymous]
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
+            if (User.Identity?.IsAuthenticated ?? false)
+            {
+                var idToken = await HttpContext.GetTokenAsync("id_token");
+                var accessToken = await HttpContext.GetTokenAsync("access_token");
+                ViewData["IdToken"] = idToken ?? string.Empty;
+                ViewData["AccessToken"] = accessToken ?? string.Empty;
+            }
+
             return View();
+        }
+
+        [Authorize]
+        [HttpPost]
+        public IActionResult Logout()
+        {
+            var callbackUrl = Url.Action("Index", "Home", values: null, protocol: Request.Scheme);
+            return SignOut(new AuthenticationProperties { RedirectUri = callbackUrl },
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                OpenIdConnectDefaults.AuthenticationScheme);
         }
     }
 }

--- a/AADConnect/Views/Home/Index.cshtml
+++ b/AADConnect/Views/Home/Index.cshtml
@@ -3,4 +3,23 @@
 }
 
 <h2>Home</h2>
-<p><a href="/Results/Tokens">View Tokens</a></p>
+
+@if (User.Identity?.IsAuthenticated ?? false)
+{
+    <form asp-action="Logout" method="post">
+        <button type="submit">Logout</button>
+    </form>
+
+    <div>
+        <label>ID Token</label><br />
+        <textarea readonly rows="10" style="width:100%">@ViewData["IdToken"]</textarea>
+    </div>
+    <div>
+        <label>Access Token</label><br />
+        <textarea readonly rows="10" style="width:100%">@ViewData["AccessToken"]</textarea>
+    </div>
+}
+else
+{
+    <p><a href="/MicrosoftIdentity/Account/SignIn">Sign In</a></p>
+}


### PR DESCRIPTION
## Summary
- retrieve id and access tokens in `HomeController`
- add `Logout` action that clears auth cookies and triggers sign-out
- show logout button and tokens on the home page

## Testing
- `dotnet build ang2.sln --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877ab90d2e0832db56c03ac0e80ee8d