### PR TITLE
Fix local logout in AADConnect

### DIFF
--- a/AADConnect/Controllers/HomeController.cs
+++ b/AADConnect/Controllers/HomeController.cs
@@ -28,14 +28,13 @@ namespace AADConnect.Controllers
         {
             var callbackUrl = Url.Action("AfterLogout", "Home", values: null, protocol: Request.Scheme);
             return SignOut(new AuthenticationProperties { RedirectUri = callbackUrl },
-                CookieAuthenticationDefaults.AuthenticationScheme,
-                OpenIdConnectDefaults.AuthenticationScheme);
+                CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         [AllowAnonymous]
         public IActionResult AfterLogout()
         {
-            return AfterLogout();
+            return View();
         }
     }
 }


### PR DESCRIPTION
## Summary
- sign out only local cookie when logging out of AADConnect
- fix recursion bug in AfterLogout view action

## Testing
- `dotnet build AADConnect/AADConnect.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877e41bcef8832db1e4cb2800fba239