### PR TITLE
Fix entity column mappings

### DIFF
--- a/flowerapi/Data/AuthDbContext.cs
+++ b/flowerapi/Data/AuthDbContext.cs
@@ -21,23 +21,30 @@ namespace AuthApi.Data
             {
                 entity.ToTable("users");
                 entity.HasKey(u => u.Id);
+                entity.Property(u => u.Id).HasColumnName("id");
                 entity.HasIndex(u => u.Email).IsUnique();
-                entity.Property(u => u.Email).HasMaxLength(255).IsRequired();
-                entity.Property(u => u.Name).HasMaxLength(255);
-                entity.Property(u => u.IsActive).HasDefaultValue(true);
-                entity.Property(u => u.CreatedAt).HasDefaultValueSql("GETDATE()");
-                entity.Property(u => u.UpdatedAt).HasDefaultValueSql("GETDATE()");
+                entity.Property(u => u.Email).HasColumnName("email").HasMaxLength(255).IsRequired();
+                entity.Property(u => u.Name).HasColumnName("name").HasMaxLength(255);
+                entity.Property(u => u.IsActive).HasColumnName("is_active").HasDefaultValue(true);
+                entity.Property(u => u.CreatedAt).HasColumnName("created_at").HasDefaultValueSql("GETDATE()");
+                entity.Property(u => u.CreatedBy).HasColumnName("created_by");
+                entity.Property(u => u.UpdatedAt).HasColumnName("updated_at").HasDefaultValueSql("GETDATE()");
+                entity.Property(u => u.UpdatedBy).HasColumnName("updated_by");
             });
 
             modelBuilder.Entity<Role>(entity =>
             {
                 entity.ToTable("roles");
                 entity.HasKey(r => r.Id);
+                entity.Property(r => r.Id).HasColumnName("id");
                 entity.HasIndex(r => r.Name).IsUnique();
-                entity.Property(r => r.Name).HasMaxLength(50).IsRequired();
-                entity.Property(r => r.RoleType).HasMaxLength(20).IsRequired();
-                entity.Property(r => r.CreatedAt).HasDefaultValueSql("GETDATE()");
-                entity.Property(r => r.UpdatedAt).HasDefaultValueSql("GETDATE()");
+                entity.Property(r => r.Name).HasColumnName("name").HasMaxLength(50).IsRequired();
+                entity.Property(r => r.Description).HasColumnName("description");
+                entity.Property(r => r.RoleType).HasColumnName("role_type").HasMaxLength(20).IsRequired();
+                entity.Property(r => r.CreatedAt).HasColumnName("created_at").HasDefaultValueSql("GETDATE()");
+                entity.Property(r => r.CreatedBy).HasColumnName("created_by");
+                entity.Property(r => r.UpdatedAt).HasColumnName("updated_at").HasDefaultValueSql("GETDATE()");
+                entity.Property(r => r.UpdatedBy).HasColumnName("updated_by");
                 entity.HasCheckConstraint("chk_role_type", "role_type IN ('global','scoped')");
             });
 
@@ -45,8 +52,12 @@ namespace AuthApi.Data
             {
                 entity.ToTable("user_roles");
                 entity.HasKey(ur => new { ur.UserId, ur.RoleId });
-                entity.Property(ur => ur.CreatedAt).HasDefaultValueSql("GETDATE()");
-                entity.Property(ur => ur.UpdatedAt).HasDefaultValueSql("GETDATE()");
+                entity.Property(ur => ur.UserId).HasColumnName("user_id");
+                entity.Property(ur => ur.RoleId).HasColumnName("role_id");
+                entity.Property(ur => ur.CreatedAt).HasColumnName("created_at").HasDefaultValueSql("GETDATE()");
+                entity.Property(ur => ur.CreatedBy).HasColumnName("created_by");
+                entity.Property(ur => ur.UpdatedAt).HasColumnName("updated_at").HasDefaultValueSql("GETDATE()");
+                entity.Property(ur => ur.UpdatedBy).HasColumnName("updated_by");
                 entity.HasOne(ur => ur.User)
                     .WithMany(u => u.UserRoles)
                     .HasForeignKey(ur => ur.UserId)

--- a/flowerapi/Models/Role.cs
+++ b/flowerapi/Models/Role.cs
@@ -1,17 +1,34 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AuthApi.Models
 {
+    [Table("roles", Schema = "auth")]
     public class Role
     {
+        [Column("id")]
         public int Id { get; set; }
+
+        [Column("name")]
         public string Name { get; set; } = null!;
+
+        [Column("description")]
         public string? Description { get; set; }
+
+        [Column("role_type")]
         public string RoleType { get; set; } = null!;
+
+        [Column("created_at")]
         public DateTime CreatedAt { get; set; }
+
+        [Column("created_by")]
         public string? CreatedBy { get; set; }
+
+        [Column("updated_at")]
         public DateTime UpdatedAt { get; set; }
+
+        [Column("updated_by")]
         public string? UpdatedBy { get; set; }
 
         public virtual ICollection<UserRole> UserRoles { get; set; } = new HashSet<UserRole>();

--- a/flowerapi/Models/User.cs
+++ b/flowerapi/Models/User.cs
@@ -1,17 +1,34 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AuthApi.Models
 {
+    [Table("users", Schema = "auth")]
     public class User
     {
+        [Column("id")]
         public int Id { get; set; }
+
+        [Column("email")]
         public string Email { get; set; } = null!;
+
+        [Column("name")]
         public string? Name { get; set; }
+
+        [Column("is_active")]
         public bool IsActive { get; set; } = true;
+
+        [Column("created_at")]
         public DateTime CreatedAt { get; set; }
+
+        [Column("created_by")]
         public string? CreatedBy { get; set; }
+
+        [Column("updated_at")]
         public DateTime UpdatedAt { get; set; }
+
+        [Column("updated_by")]
         public string? UpdatedBy { get; set; }
 
         public virtual ICollection<UserRole> UserRoles { get; set; } = new HashSet<UserRole>();

--- a/flowerapi/Models/UserRole.cs
+++ b/flowerapi/Models/UserRole.cs
@@ -1,14 +1,27 @@
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AuthApi.Models
 {
+    [Table("user_roles", Schema = "auth")]
     public class UserRole
     {
+        [Column("user_id")]
         public int UserId { get; set; }
+
+        [Column("role_id")]
         public int RoleId { get; set; }
+
+        [Column("created_at")]
         public DateTime CreatedAt { get; set; }
+
+        [Column("created_by")]
         public string? CreatedBy { get; set; }
+
+        [Column("updated_at")]
         public DateTime UpdatedAt { get; set; }
+
+        [Column("updated_by")]
         public string? UpdatedBy { get; set; }
 
         public virtual User User { get; set; } = null!;


### PR DESCRIPTION
## Summary
- map entity properties to database column names with underscores
- configure AuthDbContext with explicit column names

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687875aeea0c832d99ee527dc106dd77